### PR TITLE
docs: use the latest Discord logo

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -11,5 +11,6 @@
 </div>
     
 <p align="center">
-    <a align="center" href="https://discord.gg/3AV5Z8mRSf"><img src="https://camo.githubusercontent.com/c26e422415c93d08e0366cc8f0e8fd43927668a0acac5875038e923a11dd971f/68747470733a2f2f7777772e66726565706e676c6f676f732e636f6d2f75706c6f6164732f646973636f72642d6c6f676f2d706e672f636f6e636f7572732d646973636f72642d6361727465732d766f6575782d666f72746e6974652d6672616e63652d362e706e67" heigth="50" width="50" alt="Join our Discord community here" /></a>
+    <a align="center" href="https://discord.gg/3AV5Z8mRSf"><img alt="Join our Discord community here."
+src="https://discord.com/assets/3437c10597c1526c3dbd98c737c2bcae.svg" width="40" height="50"/></a>
 </p>


### PR DESCRIPTION
Things added/changed:

- Use the latest Discord logo.
  - It appears the previous PR I made was in the readme of the repository itself and not the profile organization. 😅
